### PR TITLE
Fix safe_path prefix issue

### DIFF
--- a/softcosim/fs.py
+++ b/softcosim/fs.py
@@ -1,11 +1,18 @@
 from pathlib import Path
+from os import path as os_path
 
 def safe_path(root: Path, target: Path) -> Path:
     """
     Resolves a target path relative to a root, ensuring it does not escape the root.
     """
+    root = root.resolve()
     p = (root / target).resolve()
-    if not str(p).startswith(str(root)):
+    try:
+        relative = p.is_relative_to(root)
+    except AttributeError:
+        # For Python <3.9; use os.path.commonpath as a fallback
+        relative = os_path.commonpath([root, p]) == str(root)
+    if not relative:
         raise ValueError(f"Path escape blocked: {p} is not within {root}")
     return p
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -50,6 +50,14 @@ def test_safe_path_blocks_escape_attempts():
              with pytest.raises(ValueError):
                 safe_path(root, other_dir / "file.txt")
 
+def test_safe_path_blocks_deceptive_prefixes():
+    """Ensure paths that merely share a prefix with root are blocked."""
+    root = Path("/tmp").resolve()
+    with pytest.raises(ValueError):
+        safe_path(root, Path("/tmpfile"))
+    with pytest.raises(ValueError):
+        safe_path(root, Path("/tmp/../tmpfile"))
+
 def test_safe_path_with_real_directories():
     """
     Tests safe_path against the current working directory structure.


### PR DESCRIPTION
## Summary
- make `safe_path` verify paths with `Path.is_relative_to` and `os.path.commonpath`
- add regression tests for deceptive prefix paths

## Testing
- `COLUMNS=200 pytest -q`