### PR TITLE
Add central sys.path handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+def pytest_configure():
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,12 +2,6 @@ import asyncio
 import pytest
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,7 @@
 from typer.testing import CliRunner
 from pathlib import Path
-import os
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from softcosim.__main__ import app
 
@@ -25,7 +21,8 @@ def test_folder_guard_blocks_existing(tmp_path):
     )
     
     assert result.exit_code != 0
-    assert "already exists" in result.stdout
+    normalized = " ".join(result.stdout.split())
+    assert "already exists" in normalized
 
 def test_folder_is_created_successfully(tmp_path, monkeypatch):
     """

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,12 +3,6 @@ import asyncio
 from typer.testing import CliRunner
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -3,11 +3,6 @@ from pathlib import Path
 import tempfile
 import os
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.fs import safe_path
 
 def test_safe_path_allows_valid_paths():

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2,12 +2,6 @@ import asyncio
 import pytest
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,11 +3,6 @@ import pytest
 from pathlib import Path
 import os
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -3,11 +3,7 @@ import pytest
 import types
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
 import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from softcosim.engine import CompanySim
 


### PR DESCRIPTION
## Summary
- insert repository root in `sys.path` using pytest `conftest`
- drop duplicated path hacks from tests
- make CLI message assertion robust

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864624a2108832fa65787f66f17c6df