### PR TITLE
Clean up prompts and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,64 @@
 # SoftCoSim
 
-A simulation of a software studio, powered by LLMs.
+A simulation of a small software studio powered by LLMs.
 
 ## High-Level Goals
 
-- A single CLI command kicks off a full “software-studio” simulation.
-- All output stays inside one root folder that the user chooses.
-- Agents (manager, lead, devs, QA, HR) talk, code, gossip, take breaks, and hit a simulated deadline.
-- Every event is streamed live to the terminal and written to markdown / code files in real time.
-- The first thing the CLI does is ask for (or read) an OpenRouter API key.
+- A single CLI command kicks off a full "software-studio" simulation.
+- All output stays inside one root folder chosen by the user.
+- Agents (manager, developer, QA) talk, code, gossip and hit a simulated deadline.
+- Every event is streamed live to the terminal and written to files.
+- The CLI first asks for (or reads) an OpenRouter API key.
 
 ## Tech Stack
 
-| Layer       | Lib / tool                        | Note                                |
-| ----------- | --------------------------------- | ----------------------------------- |
-| CLI & core  | Python 3.12, `typer`              | Auto-gen help and coloured prompts. |
-| LLM calls   | OpenRouter `/v1/chat/completions` | Model name set per agent.           |
-| Concurrency | `asyncio`                         | CPU-light, fits CLI use.            |
-| Scheduler   | `heapq`, `dataclasses`            | No extra deps.                      |
-| Terminal UI | `rich`                            | Progress bars + live tables.        |
-| Sandboxing  | Docker + `python:3.12-slim`       | Easy to spin up, predictable.       |
-| Testing     | `pytest`, `ruff`, `bandit`        | Run inside the container.           |
+| Layer       | Lib / tool                        | Notes                                  |
+| ----------- | --------------------------------- | -------------------------------------- |
+| CLI & core  | Python 3.12, `typer`              | Auto-generated help, coloured prompts. |
+| LLM calls   | OpenRouter `/v1/chat/completions` | Model name set per agent.              |
+| Concurrency | `asyncio`                         | CPU-light, fits CLI use.               |
+| Scheduler   | `heapq`, `dataclasses`            | No extra deps.                         |
+| Terminal UI | `rich`                            | Progress bars & live tables.           |
+| Sandboxing  | Docker + `python:3.12-slim`       | Easy to spin up, predictable.          |
+| Testing     | `pytest`, `ruff`, `bandit`        | Run inside the container.              |
 
 ## Usage
 
+After installing the package you can start a simulation with:
+
 ```bash
-softcosim <prompt> --hours 8 --folder ./run1
+softcosim "Build a to‑do app" --hours 8 --folder ./run1
 ```
+
+The command will prompt for an API key if `OPENROUTER_API_KEY` is not already set
+in the environment. Output files such as `timeline.md` and `gossip.md` will be
+created inside the folder you specify.
 
 ## Development
 
-To set up the development environment, run:
+1. Create a virtual environment and install the dev extras.
 
-```bash
-python -m venv .venv
-.venv\Scripts\activate.ps1
-pip install -e .[dev]
+   **Bash**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .[dev]
+   ```
+
+   **PowerShell**
+   ```powershell
+   python -m venv .venv
+   .venv\Scripts\Activate.ps1
+   pip install -e .[dev]
+   ```
+
+2. Run linters and the test suite:
+
+   ```bash
+   ruff .
+   bandit -r softcosim
+   pytest
+   ```
+
+Tests use fake LLM responses and skip Docker by default (via environment
+variables in `pyproject.toml`).

--- a/softcosim/__main__.py
+++ b/softcosim/__main__.py
@@ -11,7 +11,7 @@ app = typer.Typer(add_completion=False)
 console = Console()
 
 def abort(msg: str, code: int = 1):
-    console.print(f"[bold red]Error:[/bold red] {msg}")
+    print(f"Error: {msg}")
     raise typer.Exit(code)
 
 @app.command()


### PR DESCRIPTION
## Summary
- remove unused base prompt file
- print CLI errors without line wrapping to satisfy tests
- document dev setup, usage, and lint/test commands

## Testing
- `pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864625e3e70832fb5a79d9a4c6f0c3a