### PR TITLE
Add interactive CLI prompts and timed events

### DIFF
--- a/softcosim/__main__.py
+++ b/softcosim/__main__.py
@@ -14,13 +14,21 @@ def abort(msg: str, code: int = 1):
 
 @app.command()
 def run(
-    prompt: str = typer.Argument(..., help="Project prompt for the team"),
-    hours: int = typer.Option(8, "--hours", "-h", help="The number of simulated hours to run."),
+    prompt: str = typer.Option(None, "--prompt", "-p", help="Project prompt for the team"),
+    days: int = typer.Option(None, "--days", "-d", help="Number of days to simulate"),
+    budget: float = typer.Option(None, "--budget", "-b", help="LLM budget in USD"),
     folder: Path = typer.Option(..., "--folder", "-f", help="The root folder for the simulation output."),
 ):
-    """
-    Kicks off a new software studio simulation.
-    """
+    """Kicks off a new software studio simulation."""
+
+    console.print(":wave: Welcome to SoftCoSim!")
+    if not prompt:
+        prompt = typer.prompt("Project description")
+    if days is None:
+        days = typer.prompt("Number of days", type=int)
+    if budget is None:
+        budget = typer.prompt("LLM budget (USD)", type=float)
+
     # 1. Folder guard
     if folder.exists():
         abort(f"Output folder '{folder}' already exists.")
@@ -41,7 +49,7 @@ def run(
 
     # 3. Kick off simulation
     console.print(":rocket: Launching simulation…")
-    sim = CompanySim(prompt, hours, folder.resolve())
+    sim = CompanySim(prompt, days, folder.resolve(), budget=budget)
     asyncio.run(sim.start())
     console.print(":white_check_mark: Done.")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -20,7 +20,7 @@ async def test_developer_creates_hello(tmp_path: Path, monkeypatch):
         pass
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
-    sim = CompanySim(prompt="HelloWorld", sim_hours=1, root=tmp_path)
+    sim = CompanySim(prompt="HelloWorld", days=1, root=tmp_path)
     await sim.start()
 
     hello_path = tmp_path / "src" / "hello.py"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_folder_guard_blocks_existing(tmp_path):
     
     result = runner.invoke(
         app,
-        ["--folder", str(folder), "Test Prompt"],
+        ["--folder", str(folder), "--prompt", "Test", "--days", "1", "--budget", "1"],
         catch_exceptions=False, # Let Typer's Exit bubble up
     )
     
@@ -38,7 +38,7 @@ def test_folder_is_created_successfully(tmp_path, monkeypatch):
     
     result = runner.invoke(
         app,
-        ["--folder", str(folder), "Test Prompt"],
+        ["--folder", str(folder), "--prompt", "Test", "--days", "1", "--budget", "1"],
         catch_exceptions=False,
     )
     

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -23,7 +23,7 @@ async def test_timeline_logs_events(tmp_path: Path, monkeypatch):
     output_dir = tmp_path / "test_run"
     output_dir.mkdir()
 
-    sim = CompanySim(prompt="Test Engine", sim_hours=8, root=output_dir)
+    sim = CompanySim(prompt="Test Engine", days=1, root=output_dir)
     await sim.start()
     
     timeline_path = output_dir / "timeline.md"

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -20,7 +20,7 @@ async def test_gossip_and_morale(tmp_path: Path, monkeypatch):
         pass
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
-    sim = CompanySim(prompt="Test Gossip", sim_hours=1, root=tmp_path)
+    sim = CompanySim(prompt="Test Gossip", days=1, root=tmp_path)
     initial_morale = sim.morale
     await sim.start()
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -15,7 +15,7 @@ async def test_llm_fake_mode(tmp_path: Path, monkeypatch):
     Tests that the LLM fake mode returns canned responses and zero cost.
     """
     monkeypatch.setenv("SOFTCOSIM_FAKE_LLM", "1")
-    sim = CompanySim(prompt="Test LLM", sim_hours=1, root=tmp_path)
+    sim = CompanySim(prompt="Test LLM", days=1, root=tmp_path)
     agent = sim.agents["mgr"]
     reply = await agent.ask_llm("system", "user")
     assert reply == "FAKE-LLM-REPLY"
@@ -31,7 +31,7 @@ async def test_llm_real_mode_cost_tracking(tmp_path: Path, monkeypatch):
         pytest.skip("OPENROUTER_API_KEY not set, skipping real LLM test.")
 
     monkeypatch.setenv("SOFTCOSIM_FAKE_LLM", "0")
-    sim = CompanySim(prompt="Test LLM", sim_hours=1, root=tmp_path)
+    sim = CompanySim(prompt="Test LLM", days=1, root=tmp_path)
     agent = sim.agents["mgr"]
     await agent.ask_llm("system", "user")
     assert sim.cost > 0.0

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -29,7 +29,7 @@ async def test_qa_logs_results(tmp_path: Path, monkeypatch):
         pass
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
-    sim = CompanySim(prompt="Test QA", sim_hours=1, root=tmp_path)
+    sim = CompanySim(prompt="Test QA", days=1, root=tmp_path)
     await sim.start()
 
     qa_log_path = tmp_path / "qa" / "test_log.txt"


### PR DESCRIPTION
## Summary
- extend CLI to prompt for project info when not provided
- allow configuring days and LLM budget
- add start/end work day hours and real-time ratio
- schedule coffee breaks and meetings affecting morale
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646268bf08832fa249ec4802a811ef