### PR TITLE
Add speed and workday options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ A simulation of a small software studio powered by LLMs.
 After installing the package you can start a simulation with:
 
 ```bash
-softcosim "Build a to‑do app" --hours 8 --folder ./run1
+softcosim "Build a to‑do app" --days 2 --folder ./run1
 ```
 
 The command will prompt for an API key if `OPENROUTER_API_KEY` is not already set
 in the environment. Output files such as `timeline.md` and `gossip.md` will be
-created inside the folder you specify.
+created inside the folder you specify. To speed up the simulation, pass the
+`--speed` option where the value is the number of real seconds per simulated
+hour. For example, `--speed 2` runs at 30&nbsp;minutes per second.
 
 ## Development
 

--- a/softcosim/__main__.py
+++ b/softcosim/__main__.py
@@ -18,6 +18,21 @@ def run(
     days: int = typer.Option(None, "--days", "-d", help="Number of days to simulate"),
     budget: float = typer.Option(None, "--budget", "-b", help="LLM budget in USD"),
     folder: Path = typer.Option(..., "--folder", "-f", help="The root folder for the simulation output."),
+    start_hour: int = typer.Option(
+        None,
+        "--start-hour",
+        help="Hour the workday starts (0-23)",
+    ),
+    end_hour: int = typer.Option(
+        None,
+        "--end-hour",
+        help="Hour the workday ends (1-24)",
+    ),
+    speed: float = typer.Option(
+        None,
+        "--speed",
+        help="Seconds per simulated hour",
+    ),
 ):
     """Kicks off a new software studio simulation."""
 
@@ -28,6 +43,12 @@ def run(
         days = typer.prompt("Number of days", type=int)
     if budget is None:
         budget = typer.prompt("LLM budget (USD)", type=float)
+    if start_hour is None:
+        start_hour = typer.prompt("Start hour", type=int)
+    if end_hour is None:
+        end_hour = typer.prompt("End hour", type=int)
+    if speed is None:
+        speed = typer.prompt("Seconds per simulated hour", type=float)
 
     # 1. Folder guard
     if folder.exists():
@@ -49,7 +70,15 @@ def run(
 
     # 3. Kick off simulation
     console.print(":rocket: Launching simulation…")
-    sim = CompanySim(prompt, days, folder.resolve(), budget=budget)
+    sim = CompanySim(
+        prompt,
+        days,
+        folder.resolve(),
+        start_hour=start_hour,
+        end_hour=end_hour,
+        seconds_per_hour=speed,
+        budget=budget,
+    )
     asyncio.run(sim.start())
     console.print(":white_check_mark: Done.")
 

--- a/softcosim/agents.py
+++ b/softcosim/agents.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 import random
+from typing import TYPE_CHECKING
 from .fs import write
 from .llm import chat
+
+if TYPE_CHECKING:
+    from .engine import CompanySim
 
 class Agent:
     model = "mistralai/devstral-small"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,8 +19,23 @@ def test_folder_guard_blocks_existing(tmp_path):
     
     result = runner.invoke(
         app,
-        ["--folder", str(folder), "--prompt", "Test", "--days", "1", "--budget", "1"],
-        catch_exceptions=False, # Let Typer's Exit bubble up
+        [
+            "--folder",
+            str(folder),
+            "--prompt",
+            "Test",
+            "--days",
+            "1",
+            "--budget",
+            "1",
+            "--start-hour",
+            "9",
+            "--end-hour",
+            "17",
+            "--speed",
+            "1",
+        ],
+        catch_exceptions=False,  # Let Typer's Exit bubble up
     )
     
     assert result.exit_code != 0
@@ -38,9 +53,72 @@ def test_folder_is_created_successfully(tmp_path, monkeypatch):
     
     result = runner.invoke(
         app,
-        ["--folder", str(folder), "--prompt", "Test", "--days", "1", "--budget", "1"],
+        [
+            "--folder",
+            str(folder),
+            "--prompt",
+            "Test",
+            "--days",
+            "1",
+            "--budget",
+            "1",
+            "--start-hour",
+            "9",
+            "--end-hour",
+            "17",
+            "--speed",
+            "1",
+        ],
         catch_exceptions=False,
     )
     
     assert result.exit_code == 0, f"CLI failed with output:\n{result.stdout}"
+    assert folder.exists()
+
+
+def test_cli_accepts_time_options(tmp_path, monkeypatch):
+    """CLI parses start/end hour and speed options."""
+    folder = tmp_path / "run3"
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
+
+    result = runner.invoke(
+        app,
+        [
+            "--folder",
+            str(folder),
+            "--prompt",
+            "Test",
+            "--days",
+            "1",
+            "--budget",
+            "1",
+            "--start-hour",
+            "8",
+            "--end-hour",
+            "16",
+            "--speed",
+            "0.5",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"CLI failed with output:\n{result.stdout}"
+    assert folder.exists()
+
+
+def test_cli_prompts_for_defaults(tmp_path, monkeypatch):
+    """Missing options trigger interactive prompts."""
+    folder = tmp_path / "run4"
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
+
+    inputs = "\n".join(["Test", "1", "1", "9", "17", "1"]) + "\n"
+    result = runner.invoke(
+        app,
+        ["--folder", str(folder)],
+        input=inputs,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"CLI failed with output:\n{result.stdout}"
+    assert "Start hour" in result.stdout
     assert folder.exists()


### PR DESCRIPTION
## Summary
- support `--start-hour`, `--end-hour` and `--speed` options in the CLI
- prompt for these values when omitted
- document accelerated runs via `--speed`
- fix forward reference lint warning
- extend CLI tests for new options and prompts

## Testing
- `ruff check .`
- `bandit -r softcosim`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864683e193c832fb84c7af78468040d