### PR TITLE
Add fatigue tracking with breaks

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -30,6 +30,29 @@ async def test_timeline_logs_events(tmp_path: Path, monkeypatch):
     assert timeline_path.exists()
     
     content = timeline_path.read_text(encoding="utf-8")
+    assert "| Fatigue |" in content
     assert "Manager: Planning project" in content
     assert "Dev-A: Writing hello.py" in content
     assert "Deadline reached – stopping" in content
+
+
+@pytest.mark.asyncio
+async def test_fatigue_decay_and_recovery(tmp_path: Path, monkeypatch):
+    async def fake_sleep(_):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    sim = CompanySim(prompt="Fatigue", days=1, root=tmp_path)
+    await sim.start()
+
+    assert sim.fatigue > 0
+    max_fatigue = sim.hours_per_day * sim.FATIGUE_RATE
+    assert sim.fatigue < max_fatigue
+
+    timeline_content = (tmp_path / "timeline.md").read_text()
+    lines = [
+        l
+        for l in timeline_content.splitlines()
+        if "Coffee break" in l or "Lunch break" in l
+    ]
+    assert lines

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -37,4 +37,5 @@ async def test_gossip_and_morale(tmp_path: Path, monkeypatch):
     timeline_path = tmp_path / "timeline.md"
     timeline_content = timeline_path.read_text()
     assert "| Morale |" in timeline_content
+    assert "| Fatigue |" in timeline_content
     assert "GOSSIP" in timeline_content


### PR DESCRIPTION
## Summary
- track `fatigue` in `CompanySim` and decay it as time advances
- reduce fatigue during coffee and new lunch breaks
- log fatigue in `timeline.md`
- test fatigue behaviour and new timeline column

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646a05e7c0832fa79dbf9ba448bc0e