### PR TITLE
Implement streaming in LLM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simulation of a small software studio powered by LLMs.
 - All output stays inside one root folder chosen by the user.
 - Agents (manager, developer, QA) talk, code, gossip and hit a simulated deadline.
 - Every event is streamed live to the terminal and written to files.
+- LLM responses stream token-by-token for accurate cost tracking.
 - The CLI first asks for (or reads) an OpenRouter API key.
 
 ## Tech Stack
@@ -15,7 +16,7 @@ A simulation of a small software studio powered by LLMs.
 | Layer       | Lib / tool                        | Notes                                  |
 | ----------- | --------------------------------- | -------------------------------------- |
 | CLI & core  | Python 3.12, `typer`              | Auto-generated help, coloured prompts. |
-| LLM calls   | OpenRouter `/v1/chat/completions` | Model name set per agent.              |
+| LLM calls   | OpenRouter `/v1/chat/completions` | Streamed via `aiohttp`; model name per agent. |
 | Concurrency | `asyncio`                         | CPU-light, fits CLI use.               |
 | Scheduler   | `heapq`, `dataclasses`            | No extra deps.                         |
 | Terminal UI | `rich`                            | Progress bars & live tables.           |

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -51,8 +51,8 @@ async def test_fatigue_decay_and_recovery(tmp_path: Path, monkeypatch):
 
     timeline_content = (tmp_path / "timeline.md").read_text()
     lines = [
-        l
-        for l in timeline_content.splitlines()
-        if "Coffee break" in l or "Lunch break" in l
+        line
+        for line in timeline_content.splitlines()
+        if "Coffee break" in line or "Lunch break" in line
     ]
     assert lines

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -21,6 +21,17 @@ async def test_llm_fake_mode(tmp_path: Path, monkeypatch):
     assert reply == "FAKE-LLM-REPLY"
     assert sim.cost == 0.0
 
+
+@pytest.mark.asyncio
+async def test_llm_fake_stream_mode(tmp_path: Path, monkeypatch):
+    """Streaming mode should also return the fake reply."""
+    monkeypatch.setenv("SOFTCOSIM_FAKE_LLM", "1")
+    from softcosim.llm import chat
+    msg = [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}]
+    reply, cost, latency = await chat("model", msg, stream=True)
+    assert reply == "FAKE-LLM-REPLY"
+    assert cost == 0.0
+
 @pytest.mark.asyncio
 async def test_llm_real_mode_cost_tracking(tmp_path: Path, monkeypatch):
     """


### PR DESCRIPTION
## Summary
- implement token streaming via aiohttp
- track cost and latency for streamed responses
- document streaming in README
- test LLM streaming and fix lint warnings

## Testing
- `ruff check .`
- `bandit -r softcosim`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646b910bc0832fb3b50037162cc5a6