### PR TITLE
Add test fixture for path setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+def pytest_configure():
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,12 +2,6 @@ import asyncio
 import pytest
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,6 @@
 from typer.testing import CliRunner
 import os
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.__main__ import app
 
 runner = CliRunner()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,12 +2,6 @@ import pytest
 import asyncio
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -3,11 +3,6 @@ from pathlib import Path
 import tempfile
 import os
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.fs import safe_path
 
 def test_safe_path_allows_valid_paths():

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2,12 +2,6 @@ import asyncio
 import pytest
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -2,11 +2,6 @@ import pytest
 from pathlib import Path
 import os
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -3,12 +3,7 @@ import pytest
 import types
 from pathlib import Path
 
-# This is a bit of a hack to get the softcosim module in the path
-# A proper setup.py or pyproject.toml would handle this better
 import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from softcosim.engine import CompanySim
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` with a `pytest_configure` hook that places the repo root on `sys.path`
- clean up path insertion boilerplate from all tests
- include `sys` import where still needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646ccd34d0832faa0b7359c6cd642d