### PR TITLE
Write summary README after simulation

### DIFF
--- a/softcosim/engine.py
+++ b/softcosim/engine.py
@@ -56,6 +56,14 @@ class CompanySim:
         self._prepare_fs()
         self._schedule_initial_events()
         await self._run_loop()
+        readme = self.root / "README.md"
+        summary = (
+            "# Simulation Summary\n\n"
+            f"Prompt: {self.prompt}\n\n"
+            f"Days: {self.days}\n\n"
+            f"Final cost: ${self.cost:.4f}\n"
+        )
+        readme.write_text(summary, encoding="utf-8")
 
     def _prepare_fs(self):
         self.timeline_path.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 from typer.testing import CliRunner
-import os
 
 from softcosim.__main__ import app
 
@@ -66,9 +65,14 @@ def test_folder_is_created_successfully(tmp_path, monkeypatch):
         ],
         catch_exceptions=False,
     )
-    
+
     assert result.exit_code == 0, f"CLI failed with output:\n{result.stdout}"
     assert folder.exists()
+    readme_path = folder / "README.md"
+    assert readme_path.exists()
+    content = readme_path.read_text()
+    assert "Prompt: Test" in content
+    assert "Days: 1" in content
 
 
 def test_cli_accepts_time_options(tmp_path, monkeypatch):

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,7 +1,6 @@
 import pytest
 from pathlib import Path
 import tempfile
-import os
 
 from softcosim.fs import safe_path
 


### PR DESCRIPTION
## Summary
- record prompt, days and final cost in `README.md` after running `CompanySim`
- verify README creation in CLI test
- remove unused imports in tests

## Testing
- `ruff check .`
- `bandit -r softcosim`
- `SOFTCOSIM_FAKE_LLM=1 SOFTCOSIM_NO_DOCKER=1 OPENROUTER_API_KEY= pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646e1ac4cc832f82b176ef22c90d52